### PR TITLE
fix: use production build in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         run: npm ci
 
       - name: Build application
-        run: npm run build
+        run: npm run build:prod
 
       - name: Run accessibility tests
         run: npm run test:accessibility
@@ -167,7 +167,7 @@ jobs:
         run: npm ci
 
       - name: Build application
-        run: npm run build
+        run: npm run build:prod
 
       - name: Check bundle size
         run: |
@@ -203,7 +203,7 @@ jobs:
         run: npm ci
 
       - name: Build application
-        run: npm run build
+        run: npm run build:prod
 
       - name: Bundle analysis
         run: |


### PR DESCRIPTION
## Summary
- Fixed the issue where the deployed site shows "development" environment badge
- Updated CI workflow to use production build command

## Problem
The deployed site at resume.simonlamb.codes was showing "development" in the environment badge (bottom right corner) instead of "production". This was because the CI workflow was using `npm run build` which doesn't set the `VITE_NODE_ENV` environment variable.

## Solution
Changed all build commands in the CI workflow from `npm run build` to `npm run build:prod`. This ensures that:
- `VITE_NODE_ENV=production` is properly set during the build process
- The environment badge correctly displays "production" on the deployed site
- All build steps (accessibility check, performance budget, and main build) use the production configuration

## Changes
- Updated 3 build commands in `.github/workflows/ci.yml`
- Applied to: accessibility-check job, performance-budget job, and build job

## Testing
Once merged and deployed, the site should show "production" in the environment badge instead of "development".

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>