### PR TITLE
fix: properly set VITE_NODE_ENV for production builds

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -54,6 +54,7 @@ VITE_BUILD_DATE=${buildInfo.buildDate}
 VITE_BUILD_GIT_HASH=${buildInfo.gitHash}
 VITE_BUILD_GIT_BRANCH=${buildInfo.gitBranch}
 VITE_BUILD_ENVIRONMENT=${environment}
+VITE_NODE_ENV=${environment}
 `;
 
   const envPath = join(rootDir, '.env.build');
@@ -84,6 +85,7 @@ function runBuild(environment) {
       env: {
         ...process.env,
         NODE_ENV: nodeEnv,
+        VITE_NODE_ENV: environment,
         VITE_BUILD_VERSION: buildInfo.version,
         VITE_BUILD_DATE: buildInfo.buildDate,
       },


### PR DESCRIPTION
## Summary
- Fixed the root cause of why deployed site shows "development" environment
- The build script was setting the wrong environment variable name

## Problem
Even after PR #29 changed the CI to use `npm run build:prod`, the deployed site still showed "development" in the environment badge. Investigation revealed:
1. The build script was setting `VITE_BUILD_ENVIRONMENT`
2. But the application code was reading `VITE_NODE_ENV`
3. This mismatch meant production builds weren't actually getting the production environment set

## Solution
Updated the build script to also set `VITE_NODE_ENV` alongside the existing variables:
- Added `VITE_NODE_ENV=${environment}` to the .env.build file
- Added `VITE_NODE_ENV: environment` to the execSync environment variables

## Testing
- Ran `npm run build:prod` locally
- Verified the built files contain "production" strings
- The deployment should now correctly show "production" environment badge

## Related PRs
- #29 - Changed CI to use npm run build:prod (necessary but not sufficient)
- This PR fixes the actual root cause

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>