### PR TITLE
feat: update sidebar colors and add lamb favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Simon Lamb</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐑</text></svg>">
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Simon Lamb</title>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐑</text></svg>">
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐑</text></svg>"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/layout/NavigationHeader.tsx
+++ b/src/components/layout/NavigationHeader.tsx
@@ -76,7 +76,7 @@ const NavigationHeader: React.FC = () => {
       <motion.header
         initial={{ y: -100 }}
         animate={{ y: 0 }}
-        className="fixed top-0 left-0 right-0 z-50 bg-[oklch(0_0_0)]/95 backdrop-blur-sm border-b border-white/5"
+        className="fixed top-0 left-0 right-0 z-50 bg-slate-900/95 backdrop-blur-sm border-b border-white/5"
       >
         <div className="px-6 py-4 flex items-center justify-between">
           <Link to="/about" onClick={closeMenu}>

--- a/src/components/layout/NavigationSidebar.tsx
+++ b/src/components/layout/NavigationSidebar.tsx
@@ -88,7 +88,7 @@ const NavigationSidebar: React.FC = () => {
       initial={{ x: -100, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       transition={{ duration: 0.6 }}
-      className="fixed left-0 top-0 h-screen w-96 bg-gradient-to-b from-[oklch(0.02_0_0)] to-[oklch(0.01_0_0)] border-r border-white/5 p-12 flex flex-col justify-between z-40 shadow-elevation-3"
+      className="fixed left-0 top-0 h-screen w-96 bg-slate-900 border-r border-white/5 p-12 flex flex-col justify-between z-40"
     >
       {/* Header */}
       <div>
@@ -135,7 +135,7 @@ const NavigationSidebar: React.FC = () => {
                   aria-describedby={`nav-description-${item.id}`}
                   className={`group relative flex items-center space-x-4 w-full text-left py-3 px-2 transition-all duration-300 focus:outline-none rounded-lg ${
                     isActive ? 'text-primary' : 'text-slate-600 hover:text-slate-400'
-                  } ${isActive ? 'bg-[oklch(0.06_0_0_/_10%)]' : 'hover:bg-[oklch(0.06_0_0_/_5%)]'}`}
+                  } ${isActive ? 'bg-slate-800/20' : 'hover:bg-slate-800/10'}`}
                 >
                   {/* Animated gradient indicator */}
                   <div className="relative">


### PR DESCRIPTION
## Summary
- Updated sidebar from black gradient to solid slate-900 for a softer, more sophisticated look
- Added lamb emoji (🐑) as website favicon for personality
- Removed shadow elevation from sidebar for cleaner appearance

## Changes
- Changed sidebar background from `from-[oklch(0.02_0_0)] to-[oklch(0.01_0_0)]` to solid `bg-slate-900`
- Updated hover states to use `bg-slate-800/20` and `bg-slate-800/10`
- Updated mobile navigation header to match with `bg-slate-900/95`
- Added lamb emoji favicon using inline SVG data URL
- Removed `shadow-elevation-3` class from sidebar

## Visual Impact
The slate-900 color (#0f172a) provides a sophisticated dark blue-gray that's easier on the eyes than pure black while maintaining excellent contrast with the cyan/teal accent colors.

🤖 Generated with [Claude Code](https://claude.ai/code)