### PR TITLE
fix: update translations and test files to align with Principal title

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Simon Lamb - Senior AI/ML Engineering Manager specializing in GenAI, MLOps, and AI platform engineering. Building scalable AI systems and leading technical teams."
+      content="Simon Lamb - Principal AI/ML Engineering Manager specializing in GenAI, MLOps, and AI platform engineering. Building scalable AI systems and leading technical teams."
     />
     <title>Simon Lamb</title>
     <link

--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -64,7 +64,7 @@ export const portfolioData: PortfolioData = {
       "Earlier at Microsoft, I served as Technical Evangelist and later DevOps OpenHack Tech Lead. I led global OpenHacks in Melbourne, Sydney (with Satya Nadella's ANZ visit), Canberra, Las Vegas (Inspire/Ready), and Seattle (TechReady), directing coach teams and mentoring hundreds of engineers with near-perfect satisfaction scores (~95%+).",
       'My roots are in Fred IT Group, where I was Tech Architect/DevOps Lead for regulated healthcare platforms, embedding SRE practices (SLOs/SLIs, error budgets), IaC, and CI/CD to deliver clinical-grade reliability.',
       'Core stack: Azure OpenAI, RAG (vector/hybrid), Semantic Kernel/LangChain, Azure AI Search, Databricks/Delta/Unity Catalog, MLflow, Azure ML, AKS, GitHub Actions/Azure DevOps, Bicep/Terraform, GitOps (Flux/Argo), OPA/Azure Policy, Managed Identity/Key Vault, Azure Monitor/Grafana/Prometheus, SRE practices, Python, C#.',
-      "I'm open to Senior AI Engineer / Senior Data Scientist (GenAI) / Principal Engineer roles, where I can apply my mix of AI platform engineering + DevOps leadership to deliver impact at scale.",
+      "I'm open to Principal AI Engineer / Principal Data Scientist (GenAI) / Principal Engineer roles, where I can apply my mix of AI platform engineering + DevOps leadership to deliver impact at scale.",
     ],
   },
   navigation: [

--- a/src/i18n/i18n.test.tsx
+++ b/src/i18n/i18n.test.tsx
@@ -67,8 +67,9 @@ const testI18nConfig = {
         },
         about: {
           title: "Hi, I'm {{name}}.",
-          subtitle: 'Senior Frontend Engineer',
-          tagline: 'I build pixel-perfect, engaging, and accessible digital experiences.',
+          subtitle: 'Principal AI/Software Engineer | GenAI/RAG, LLMOps, SRE',
+          tagline:
+            'I build production GenAI platforms on Microsoft Azure and bring DevOps leadership from the ground up.',
           heading: 'About',
           paragraph1: 'Test paragraph 1',
           paragraph2: 'Test paragraph 2',
@@ -90,8 +91,9 @@ const testI18nConfig = {
         },
         about: {
           title: 'Hola, soy {{name}}.',
-          subtitle: 'Ingeniero Frontend Senior',
-          tagline: 'Construyo experiencias digitales perfectas, atractivas y accesibles.',
+          subtitle: 'Ingeniero Principal de IA/Software | GenAI/RAG, LLMOps, SRE',
+          tagline:
+            'Construyo plataformas GenAI de producción en Microsoft Azure y aporto liderazgo DevOps desde cero.',
           heading: 'Acerca de',
           paragraph1: 'Párrafo de prueba 1',
           paragraph2: 'Párrafo de prueba 2',
@@ -127,7 +129,9 @@ describe.skip('Internationalization', () => {
     renderWithI18n(<AboutPage />);
 
     expect(screen.getByText("Hi, I'm Simon Lamb.")).toBeInTheDocument();
-    expect(screen.getByText('Senior Frontend Engineer')).toBeInTheDocument();
+    expect(
+      screen.getByText('Principal AI/Software Engineer | GenAI/RAG, LLMOps, SRE')
+    ).toBeInTheDocument();
     expect(screen.getByText('About')).toBeInTheDocument();
   });
 
@@ -135,7 +139,9 @@ describe.skip('Internationalization', () => {
     renderWithI18n(<AboutPage />, 'es');
 
     expect(screen.getByText('Hola, soy Simon Lamb.')).toBeInTheDocument();
-    expect(screen.getByText('Ingeniero Frontend Senior')).toBeInTheDocument();
+    expect(
+      screen.getByText('Ingeniero Principal de IA/Software | GenAI/RAG, LLMOps, SRE')
+    ).toBeInTheDocument();
     expect(screen.getByText('Acerca de')).toBeInTheDocument();
   });
 
@@ -184,6 +190,6 @@ describe.skip('Internationalization', () => {
     );
 
     // Should fallback to English if French translation is missing
-    expect(screen.getByText(/Hi, I'm|Senior Frontend Engineer/)).toBeInTheDocument();
+    expect(screen.getByText(/Hi, I'm|Principal AI\/Software Engineer/)).toBeInTheDocument();
   });
 });

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -7,14 +7,12 @@
   },
   "about": {
     "title": "Hola, soy {{name}}.",
-    "subtitle": "Ingeniero de Software Principal",
-    "tagline": "Con un historial comprobado en sistemas de IA, Azure y DevOps a escala empresarial.",
+    "subtitle": "Ingeniero Principal de IA/Software | GenAI/RAG, LLMOps, SRE",
+    "tagline": "Construyo plataformas GenAI de producción en Microsoft Azure y aporto liderazgo DevOps desde cero.",
     "heading": "Acerca de",
-    "paragraph1": "Soy un ingeniero de software experimentado con más de dos décadas de experiencia, incluyendo casi nueve años en Microsoft. Mi carrera ha abarcado roles desde Evangelista Técnico en Experiencia del Desarrollador hasta Arquitecto de Soluciones en la Nube con Global Partner Solutions, culminando como Ingeniero de Software Senior en Azure Core (One Fleet Partner).",
-    "paragraph2": "A lo largo de mi tiempo en Microsoft, he desarrollado una profunda experiencia en ingeniería de nube de Azure, prácticas DevOps y desarrollo de software impulsado por IA. Notablemente, he colaborado estrechamente con los equipos de Semantic Kernel y Copilot en Microsoft para construir soluciones de IA de vanguardia.",
-    "paragraph3": "Antes de Microsoft, pasé 13 años en Fred IT Group como Arquitecto Técnico Principal, gestionando un equipo de seis ingenieros para diseñar plataformas escalables para la industria farmacéutica y de atención médica.",
-    "paragraph4": "Con la IA ahora siendo una parte integral del desarrollo, he elegido buscar soluciones que incorporen y sean complementadas por la IA, en lugar de preocuparme por lo que la IA eliminará. Con eso en mente, estoy intensamente enfocado en dominar e integrar herramientas de codificación agéntica, empoderando a los ingenieros de nube para aprovechar la IA de manera proactiva y mantenerse a la vanguardia.",
-    "paragraph5": "Fuera del trabajo, co-crío dos adolescentes con mi pareja, me esfuerzo por automatizar mi hogar, disfruto del tiempo con mi perro Pip (nombrado por el gestor de paquetes de Python), y actúo como vocalista en una banda de covers."
+    "paragraph1": "Diseño sistemas de IA de producción a escala. En Microsoft Azure Core, construí plataformas que analizan millones de líneas de código usando LLMs para identificar riesgos de seguridad y problemas de gobernanza antes del despliegue.",
+    "paragraph2": "Mi experiencia abarca toda la pila de IA: Azure OpenAI, pipelines RAG, LLMOps/MLOps, optimización de tokens y sistemas de evaluación con humano en el bucle. Aporto más de 15 años de liderazgo DevOps y prácticas SRE para garantizar que estos sistemas ofrezcan confiabilidad de grado clínico.",
+    "paragraph3": "Abierto a roles de Ingeniero Principal donde pueda aplicar ingeniería de plataforma de IA y liderazgo DevOps para generar impacto a escala."
   },
   "experience": {
     "title": "Experiencia",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -7,14 +7,12 @@
   },
   "about": {
     "title": "Salut, je suis {{name}}.",
-    "subtitle": "Ingénieur Logiciel Principal",
-    "tagline": "Avec une expérience prouvée dans les systèmes IA, Azure et DevOps à l'échelle d'entreprise.",
+    "subtitle": "Ingénieur Principal IA/Logiciel | GenAI/RAG, LLMOps, SRE",
+    "tagline": "Je construis des plateformes GenAI de production sur Microsoft Azure et apporte un leadership DevOps depuis la base.",
     "heading": "À propos",
-    "paragraph1": "Je suis un ingénieur logiciel expérimenté avec plus de deux décennies d'expérience, dont près de neuf ans chez Microsoft. Ma carrière a englobé des rôles d'Évangéliste Technique en Expérience Développeur à Architecte Solutions Cloud avec Global Partner Solutions, culminant en tant qu'Ingénieur Logiciel Senior dans Azure Core (One Fleet Partner).",
-    "paragraph2": "Tout au long de mon mandat chez Microsoft, j'ai développé une expertise approfondie en ingénierie cloud Azure, pratiques DevOps et développement logiciel piloté par l'IA. Notamment, j'ai collaboré étroitement avec les équipes Semantic Kernel et Copilot chez Microsoft pour construire des solutions IA de pointe.",
-    "paragraph3": "Avant Microsoft, j'ai passé 13 ans chez Fred IT Group en tant qu'Architecte Technique Principal, gérant une équipe de six ingénieurs pour concevoir des plateformes évolutives pour l'industrie pharmaceutique et de la santé.",
-    "paragraph4": "Avec l'IA maintenant partie intégrante du développement, j'ai choisi de chercher des solutions qui incorporent et sont complétées par l'IA, plutôt que de m'inquiéter de ce que l'IA éliminera. Dans cet esprit, je me concentre intensément sur la maîtrise et l'intégration d'outils de codage agentiques, permettant aux ingénieurs cloud de tirer parti de l'IA de manière proactive et de rester en avance.",
-    "paragraph5": "En dehors du travail, je co-élève deux adolescents avec ma partenaire, m'efforce d'automatiser ma maison, profite du temps avec mon chien Pip (nommé d'après le gestionnaire de paquets Python), et me produis comme chanteur dans un groupe de reprises."
+    "paragraph1": "Je conçois des systèmes IA de production à grande échelle. Chez Microsoft Azure Core, j'ai construit des plateformes qui analysent des millions de lignes de code en utilisant des LLMs pour identifier les risques de sécurité et les problèmes de gouvernance avant le déploiement.",
+    "paragraph2": "Mon expertise couvre toute la pile IA : Azure OpenAI, pipelines RAG, LLMOps/MLOps, optimisation des tokens et systèmes d'évaluation avec humain dans la boucle. J'apporte plus de 15 ans de leadership DevOps et de pratiques SRE pour garantir que ces systèmes offrent une fiabilité de niveau clinique.",
+    "paragraph3": "Ouvert aux rôles d'Ingénieur Principal où je peux appliquer l'ingénierie de plateforme IA et le leadership DevOps pour générer un impact à grande échelle."
   },
   "experience": {
     "title": "Expérience",

--- a/src/router/AppRouter.test.tsx
+++ b/src/router/AppRouter.test.tsx
@@ -103,7 +103,7 @@ describe.skip('AppRouter', () => {
     render(<RouterProvider router={router} />);
 
     expect(screen.getByText('Experience')).toBeInTheDocument();
-    expect(screen.getByText('Senior Frontend Engineer')).toBeInTheDocument();
+    expect(screen.getByText('Principal AI/Software Engineer')).toBeInTheDocument();
   });
 
   it('should render ProjectsPage on /projects path', () => {
@@ -111,7 +111,9 @@ describe.skip('AppRouter', () => {
     render(<RouterProvider router={router} />);
 
     expect(screen.getByText('Projects')).toBeInTheDocument();
-    expect(screen.getByText('E-Commerce Platform')).toBeInTheDocument();
+    expect(
+      screen.getByText('LLM-Driven Governance Platform - Microsoft Azure Core')
+    ).toBeInTheDocument();
   });
 
   it('should render ContactPage on /contact path', () => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -17,8 +17,9 @@ vi.mock('react-i18next', () => ({
       const translations: Record<string, string> = {
         // About page translations
         'about.title': "Hi, I'm {{name}}.",
-        'about.subtitle': 'Senior Frontend Engineer',
-        'about.tagline': 'I build pixel-perfect, engaging, and accessible digital experiences.',
+        'about.subtitle': 'Principal AI/Software Engineer | GenAI/RAG, LLMOps, SRE',
+        'about.tagline':
+          'I build production GenAI platforms on Microsoft Azure and bring DevOps leadership from the ground up.',
         'about.heading': 'About',
         'about.paragraph1': 'Test paragraph 1',
         'about.paragraph2': 'Test paragraph 2',
@@ -72,7 +73,7 @@ vi.mock('react-i18next', () => ({
       // Handle Spanish translations for testing
       const spanishTranslations: Record<string, string> = {
         'about.title': 'Hola, soy {{name}}.',
-        'about.subtitle': 'Ingeniero Frontend Senior',
+        'about.subtitle': 'Ingeniero Principal de IA/Software | GenAI/RAG, LLMOps, SRE',
         'about.heading': 'Acerca de',
       };
 


### PR DESCRIPTION
## Summary
Updates all translation files and test fixtures to reflect the change from "Senior" to "Principal" title and align with the condensed About page content.

## Changes

### Translation Updates
- ✅ Updated Spanish translations:
  - Changed subtitle to "Ingeniero Principal de IA/Software | GenAI/RAG, LLMOps, SRE"
  - Condensed About page content from 5 paragraphs to 3
  - Updated tagline to focus on GenAI platforms and DevOps leadership

- ✅ Updated French translations:
  - Changed subtitle to "Ingénieur Principal IA/Logiciel | GenAI/RAG, LLMOps, SRE" 
  - Aligned with condensed 3-paragraph structure
  - Consistent messaging across all languages

### Test Updates
- ✅ Fixed `i18n.test.tsx` to expect Principal title in test fixtures
- ✅ Updated `test/setup.ts` mock translations to match new content
- ✅ Fixed `AppRouter.test.tsx`:
  - Experience page test now expects "Principal AI/Software Engineer"
  - Projects page test uses actual project title from portfolio data

## Testing
- [x] All test files updated with correct expectations
- [x] Translations consistent across EN, ES, and FR
- [x] Test fixtures align with production content

🤖 Generated with [Claude Code](https://claude.ai/code)