### PR TITLE
Fix: Add navigation icons to mobile menu

### DIFF
--- a/src/components/layout/NavigationHeader.tsx
+++ b/src/components/layout/NavigationHeader.tsx
@@ -154,12 +154,116 @@ const NavigationHeader: React.FC = () => {
                           to={routePath}
                           onClick={closeMenu}
                           aria-current={isActive ? 'page' : undefined}
-                          className={`block py-3 px-4 rounded-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-teal-300/50 focus:ring-offset-2 focus:ring-offset-slate-900 ${
+                          className={`flex items-center py-3 px-4 rounded-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-teal-300/50 focus:ring-offset-2 focus:ring-offset-slate-900 ${
                             isActive
                               ? 'bg-teal-600/20 text-teal-300 border-l-4 border-teal-300'
                               : 'text-slate-400 hover:text-slate-100 hover:bg-slate-800/50'
                           }`}
                         >
+                          {/* Blog icon - podcast/broadcasting */}
+                          {item.id === 'blog' && (
+                            <svg
+                              width="20"
+                              height="20"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="mr-3 flex-shrink-0"
+                            >
+                              <path
+                                d="M12 14C13.1 14 14 13.1 14 12V6C14 4.9 13.1 4 12 4C10.9 4 10 4.9 10 6V12C10 13.1 10.9 14 12 14Z"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinejoin="round"
+                              />
+                              <path
+                                d="M12 14V20"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                              />
+                              <path
+                                d="M7 8C5.5 8 5.5 10 5.5 10C5.5 10 5.5 12 7 12M4 6C2 6 2 10 2 10C2 10 2 14 4 14"
+                                stroke="currentColor"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                              />
+                              <path
+                                d="M17 8C18.5 8 18.5 10 18.5 10C18.5 10 18.5 12 17 12M20 6C22 6 22 10 22 10C22 10 22 14 20 14"
+                                stroke="currentColor"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                              />
+                            </svg>
+                          )}
+                          {/* Experience icon - briefcase */}
+                          {item.id === 'experience' && (
+                            <svg
+                              width="20"
+                              height="20"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="mr-3 flex-shrink-0"
+                            >
+                              <rect
+                                x="3"
+                                y="7"
+                                width="18"
+                                height="13"
+                                rx="2"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                              <path
+                                d="M8 7V5C8 3.89543 8.89543 3 10 3H14C15.1046 3 16 3.89543 16 5V7"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                              <path
+                                d="M12 12V12.01"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                              />
+                              <path
+                                d="M3 12H21"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                              />
+                            </svg>
+                          )}
+                          {/* Projects icon - folder */}
+                          {item.id === 'projects' && (
+                            <svg
+                              width="20"
+                              height="20"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="mr-3 flex-shrink-0"
+                            >
+                              <path
+                                d="M3 7V18C3 19.1046 3.89543 20 5 20H19C20.1046 20 21 19.1046 21 18V9C21 7.89543 20.1046 7 19 7H11L9 4H5C3.89543 4 3 4.89543 3 6V7Z"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                              <path
+                                d="M7 13L10 16L17 9"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                            </svg>
+                          )}
                           <span className="text-lg font-medium tracking-wide uppercase">
                             {item.label}
                           </span>


### PR DESCRIPTION
## Summary
Adds the missing navigation icons to the mobile menu to match the desktop sidebar layout.

## Changes
- Added custom SVG icons for Insights, Experience, and Projects in mobile navigation
- Icons match the exact design used in the desktop sidebar
- Proper spacing and alignment with flex layout
- Contact and About Me items remain without icons (as designed)

## Visual Changes
- Mobile menu now displays icons next to navigation items
- Consistent visual hierarchy across all responsive breakpoints

🤖 Generated with [Claude Code](https://claude.ai/code)